### PR TITLE
Renames most 'shadow' references for clarity

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,13 +5,13 @@
 
 http://localhost:8080 {
     route /new {
-        shadow {
+        mirror {
             metrics path_new
             compare_jq .id
             primary {
                 respond "{\"id\":\"foo\", \"done\":\"ok\"}"
             }
-            shadow {
+            secondary {
                 respond "{\"id\":\"bar\", \"done\":\"ok\"}"
             }
         }

--- a/comparisons.go
+++ b/comparisons.go
@@ -1,4 +1,4 @@
-package shadow
+package mirror
 
 import (
 	"encoding/json"

--- a/comparisons_test.go
+++ b/comparisons_test.go
@@ -1,4 +1,4 @@
-package shadow
+package mirror
 
 import (
 	"github.com/itchyny/gojq"
@@ -179,7 +179,7 @@ func TestHandler_compareJSON(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "missing prop in shadow",
+			name: "missing prop in secondary",
 			fields: fields{
 				ComparisonConfig: ComparisonConfig{
 					compareJQ: []*gojq.Query{
@@ -215,7 +215,7 @@ func TestHandler_compareJSON(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "primary object, shadow string",
+			name: "primary object, secondary string",
 			fields: fields{
 				ComparisonConfig: ComparisonConfig{
 					compareJQ: []*gojq.Query{
@@ -287,7 +287,7 @@ func TestHandler_compareJSON(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "primary array, shadow string",
+			name: "primary array, secondary string",
 			fields: fields{
 				ComparisonConfig: ComparisonConfig{
 					compareJQ: []*gojq.Query{
@@ -305,7 +305,7 @@ func TestHandler_compareJSON(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "primary string, shadow array",
+			name: "primary string, secondary array",
 			fields: fields{
 				ComparisonConfig: ComparisonConfig{
 					compareJQ: []*gojq.Query{
@@ -323,7 +323,7 @@ func TestHandler_compareJSON(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "primary string, shadow bool",
+			name: "primary string, secondary bool",
 			fields: fields{
 				ComparisonConfig: ComparisonConfig{
 					compareJQ: []*gojq.Query{

--- a/io.go
+++ b/io.go
@@ -1,4 +1,4 @@
-package shadow
+package mirror
 
 import (
 	"io"

--- a/metrics.go
+++ b/metrics.go
@@ -1,4 +1,4 @@
-package shadow
+package mirror
 
 import (
 	"time"
@@ -25,13 +25,13 @@ func (m *metrics) provision(ctx caddy.Context, name string) {
 		Buckets:   prometheus.ExponentialBuckets(millisecond, 2, 16),
 	})
 	ctx.GetMetricsRegistry().Register(m.ttfb["primary"])
-	m.ttfb["shadow"] = prometheus.NewHistogram(prometheus.HistogramOpts{
+	m.ttfb["secondary"] = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: name,
 		Name:      "shadow_time_to_first_byte_seconds",
-		Help:      "Number of milliseconds before first byte of response from shadow",
+		Help:      "Number of milliseconds before first byte of response from secondary",
 		Buckets:   prometheus.ExponentialBuckets(millisecond, 2, 16),
 	})
-	ctx.GetMetricsRegistry().Register(m.ttfb["shadow"])
+	ctx.GetMetricsRegistry().Register(m.ttfb["secondary"])
 
 	m.totalTime = make(map[string]prometheus.Histogram, 2)
 	m.totalTime["primary"] = prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -41,11 +41,11 @@ func (m *metrics) provision(ctx caddy.Context, name string) {
 		Buckets:   prometheus.ExponentialBuckets(millisecond*2, 2, 16),
 	})
 	ctx.GetMetricsRegistry().Register(m.totalTime["primary"])
-	m.totalTime["shadow"] = prometheus.NewHistogram(prometheus.HistogramOpts{
+	m.totalTime["secondary"] = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: name,
 		Name:      "shadow_total_time_seconds",
-		Help:      "Number of milliseconds for full response from shadow",
+		Help:      "Number of milliseconds for full response from secondary",
 		Buckets:   prometheus.ExponentialBuckets(millisecond*2, 2, 16),
 	})
-	ctx.GetMetricsRegistry().Register(m.totalTime["shadow"])
+	ctx.GetMetricsRegistry().Register(m.totalTime["secondary"])
 }

--- a/provision.go
+++ b/provision.go
@@ -1,4 +1,4 @@
-package shadow
+package mirror
 
 import (
 	"fmt"
@@ -67,27 +67,27 @@ func (h *Handler) Provision(ctx caddy.Context) (err error) {
 
 func (h *Handler) provisionHandlers(ctx caddy.Context) (err error) {
 	var mod any
-	mod, err = ctx.LoadModuleByID("http.handlers.subroute", h.ShadowRaw)
+	mod, err = ctx.LoadModuleByID("http.handlers.subroute", h.SecondaryRaw)
 	if err != nil {
-		return fmt.Errorf("error loading shadow module: %w", err)
+		return fmt.Errorf("error loading secondary module: %w", err)
 	}
-	h.shadow = mod.(caddyhttp.MiddlewareHandler)
+	h.secondary = mod.(caddyhttp.MiddlewareHandler)
 	mod, err = ctx.LoadModuleByID("http.handlers.subroute", h.PrimaryRaw)
 	if err != nil {
 		return fmt.Errorf("error loading primary module: %w", err)
 	}
 	h.primary = mod.(caddyhttp.MiddlewareHandler)
 
-	if provisioner, ok := h.shadow.(caddy.Provisioner); ok {
+	if provisioner, ok := h.secondary.(caddy.Provisioner); ok {
 		err = provisioner.Provision(ctx)
 		if err != nil {
-			return fmt.Errorf("error provisioning shadow: %w", err)
+			return fmt.Errorf("error provisioning secondary: %w", err)
 		}
 	}
 	if provisioner, ok := h.primary.(caddy.Provisioner); ok {
 		err = provisioner.Provision(ctx)
 		if err != nil {
-			return fmt.Errorf("error provisioning shadow: %w", err)
+			return fmt.Errorf("error provisioning secondary: %w", err)
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,7 @@
 > Any change before `v1.0.0` may be a breaking change. If you choose to incorporate this into your xcaddy build,
 > please use a tagged release and read release notes if you upgrade to a newer version.
 
-caddy-shadow is
-a [Shadow Testing](https://microsoft.github.io/code-with-engineering-playbook/automated-testing/shadow-testing/) module
-for Caddy 2, with full Caddyfile support.
+caddy-mirror is a Request Mirroring and [Shadow Testing](https://microsoft.github.io/code-with-engineering-playbook/automated-testing/shadow-testing/) module for Caddy 2, with full Caddyfile support.
 
 ## Features
 
@@ -17,7 +15,7 @@ for Caddy 2, with full Caddyfile support.
 - Optional response timing metrics for Prometheus
     - Primary/Shadow Time to First Byte
     - Primary/Shadow Total Response Time
-- Optional response comparison
+- Optional shadow testing via response comparison
     - Full response body comparison
     - Configurable selective comparison of JSON responses (powered by [itchyny/gojq](https://github.com/itchyny/gojq))
     - Configurable response header comparison
@@ -53,7 +51,7 @@ Caddy with this plugin included.
 
 ## Caddyfile
 
-caddy-shadow fully supports Caddyfile as well as native JSON configuration.
+caddy-mirror fully supports Caddyfile as well as native JSON configuration.
 
 ### Example File
 
@@ -63,13 +61,13 @@ caddy-shadow fully supports Caddyfile as well as native JSON configuration.
 }
 
 http://localhost:8080 {
-    shadow {
+    mirror {
         metrics shadow
         compare_body
         primary {
             reverse_proxy https://my-old-backend.com
         }
-        shadow {
+        secondary {
             reverse_proxy https://my-new-backend.com
         }
     }
@@ -78,17 +76,17 @@ http://localhost:8080 {
 
 ### Caddyfile Options
 
-| Name              | Description                                           | Required? | Arguments            | Default |
-|-------------------|-------------------------------------------------------|-----------|----------------------|---------|
-| `primary`         | The primary/vcurrent definition                       | Required  | Subroute             |         |
-| `shadow`          | The shadow/vcurrent definition                        | Required  | Subroute             |         |
-| `compare_status`  | Enables response-status comparison                    | Optional  |                      | false   |
-| `compare_headers` | Enables response-status comparison                    | Optional  | List of header names | false   |
-| `compare_body`    | Enables response-body comparison                      | Optional  |                      | false   |
-| `compare_jq`      | Enables jq-based response comparison                  | Optional  | List of jq queries   |         |
-| `no_log`          | Disables logging for mismatched responses             | Optional  |                      | false   |
-| `metrics`         | Enables metrics                                       | Optional  | Prefix/Namespace     |         |
-| `shadow_timeout`  | Set the maximum time to wait for the shadowed request | Optional  | Duration string      | 30s     |
+| Name                | Description                                          | Required? | Arguments            | Default |
+|---------------------|------------------------------------------------------|-----------|----------------------|---------|
+| `primary`           | The primary handler definition                       | Required  | Subroute             |         |
+| `secondary`         | The secondary handler definition                     | Required  | Subroute             |         |
+| `compare_status`    | Enables response-status comparison                   | Optional  |                      | false   |
+| `compare_headers`   | Enables response-status comparison                   | Optional  | List of header names | false   |
+| `compare_body`      | Enables response-body comparison                     | Optional  |                      | false   |
+| `compare_jq`        | Enables jq-based response comparison                 | Optional  | List of jq queries   |         |
+| `no_log`            | Disables logging for mismatched responses            | Optional  |                      | false   |
+| `metrics`           | Enables metrics                                      | Optional  | Prefix/Namespace     |         |
+| `secondary_timeout` | Set the maximum time to wait for the mirroed request | Optional  | Duration string      | 30s     |
 
 ## Response Comparison
 


### PR DESCRIPTION
The previous version of this overused the word "shadow," so those references have been...

- Kept as "shadow"
- Renamed to "mirror"
- or Renamed to "secondary"